### PR TITLE
Function mysql_result returns incorrect data after first call

### DIFF
--- a/mysql2i.class.php
+++ b/mysql2i.class.php
@@ -467,6 +467,7 @@ class mysql2i
 
         mysqli_data_seek($result, $row);
         if (!empty($field)) {
+            mysqli_field_seek($result, 0);
             while ($finfo = mysqli_fetch_field($result)) {
                 if ($field == $finfo->name) {
                     $f = mysqli_fetch_assoc($result);


### PR DESCRIPTION
Call mysql_result is incorrect, because it don't reset field pointer.